### PR TITLE
allow number keys to skip to a percentage of the video

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A plugin for Video.js that enables keyboard hotkeys when the player has focus.
 * M key toggles mute/unmute.
 * F key toggles fullscreen off and on. (Does not work in Internet Explorer, it seems to be a limitation where scripts cannot request fullscreen without a mouse click)
 * Double-clicking with the mouse toggles fullscreen off and on.
+* Number keys from 0-9 skip to a percentage of the video. 0 is 0% and 9 is 90%.
 
 ## Usage
 Include the plugin:
@@ -35,7 +36,8 @@ videojs('vidId').ready(function() {
     volumeStep: 0.1,
     seekStep: 5,
     enableMute: true,
-    enableFullscreen: true
+    enableFullscreen: true,
+    enableNumbers: true
   });
 });
 ```
@@ -46,3 +48,4 @@ videojs('vidId').ready(function() {
 - `seekStep` (integer): The number of seconds to seek forward and backwards when using the Right and Left Arrow keys (default: `5`)
 - `enableMute` (boolean): Enables the volume mute to be toggle by pressing the **M** key (default: `true`)
 - `enableFullscreen` (boolean): Enables toggling the video fullscreen by pressing the **F** key (default: `true`)
+- `enableNumbers` (boolean): Enables seeking the video by pressing the number keys (default `true`)

--- a/videojs.hotkeys.js
+++ b/videojs.hotkeys.js
@@ -16,7 +16,8 @@
       volumeStep: 0.1,
       seekStep: 5,
       enableMute: true,
-      enableFullscreen: true
+      enableFullscreen: true,
+      enableNumbers: true
     };
     options = options || {};
 
@@ -40,6 +41,7 @@
       var seekStep = options.seekStep || def_options.seekStep;
       var enableMute = options.enableMute || def_options.enableMute;
       var enableFull = options.enableFullscreen || def_options.enableFullscreen;
+      var enableNumbers = options.enableNumbers || def_options.enableNumbers;
 
       // When controls are disabled, hotkeys will be disabled as well
       if (player.controls()) {
@@ -107,6 +109,15 @@
               }
             }
           }
+
+          else if ([48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58].indexOf(event.which) > -1) {
+            if (enableNumbers){
+              var number = event.which - 48;
+              event.preventDefault();
+              player.currentTime(player.duration() * number * 0.1); 
+            }
+          }
+
         }
       }
     };


### PR DESCRIPTION
This PR allows number keys to skip to a percentage of the video, like youtube.