### PR TITLE
Fix for overwriting browser hotkeys with numbers (Ctrl, Alt, Cmd + Number)

### DIFF
--- a/videojs.hotkeys.js
+++ b/videojs.hotkeys.js
@@ -192,8 +192,8 @@
             default:
               // Number keys from 0-9 skip to a percentage of the video. 0 is 0% and 9 is 90%
               if ((ewhich > 47 && ewhich < 59) || (ewhich > 95 && ewhich < 106)) {
-                // Do not handle if enableModifiersForNumbers set to false and keys are Ctrl or Cmd
-                if (enableModifiersForNumbers || !(event.metaKey || event.ctrlKey)) {
+                // Do not handle if enableModifiersForNumbers set to false and keys are Ctrl, Cmd or Alt
+                if (enableModifiersForNumbers || !(event.metaKey || event.ctrlKey || event.altKey)) {
                   if (enableNumbers) {
                     var sub = 48;
                     if (ewhich > 95) {

--- a/videojs.hotkeys.js
+++ b/videojs.hotkeys.js
@@ -32,6 +32,7 @@
       enableNumbers: true,
       enableJogStyle: false,
       alwaysCaptureHotkeys: false,
+      enableModifiersForNumbers: true,
       playPauseKey: playPauseKey,
       rewindKey: rewindKey,
       forwardKey: forwardKey,
@@ -61,7 +62,8 @@
       enableFull = options.enableFullscreen,
       enableNumbers = options.enableNumbers,
       enableJogStyle = options.enableJogStyle,
-      alwaysCaptureHotkeys = options.alwaysCaptureHotkeys;
+      alwaysCaptureHotkeys = options.alwaysCaptureHotkeys,
+      enableModifiersForNumbers = options.enableModifiersForNumbers;
 
     // Set default player tabindex to handle keydown and doubleclick events
     if (!pEl.hasAttribute('tabIndex')) {
@@ -190,14 +192,17 @@
             default:
               // Number keys from 0-9 skip to a percentage of the video. 0 is 0% and 9 is 90%
               if ((ewhich > 47 && ewhich < 59) || (ewhich > 95 && ewhich < 106)) {
-                if (enableNumbers) {
-                  var sub = 48;
-                  if (ewhich > 95) {
-                    sub = 96;
+                // Do not handle if enableModifiersForNumbers set to false and keys are Ctrl or Cmd
+                if (enableModifiersForNumbers || !(event.metaKey || event.ctrlKey)) {
+                  if (enableNumbers) {
+                    var sub = 48;
+                    if (ewhich > 95) {
+                      sub = 96;
+                    }
+                    var number = ewhich - sub;
+                    ePreventDefault();
+                    player.currentTime(player.duration() * number * 0.1);
                   }
-                  var number = ewhich - sub;
-                  ePreventDefault();
-                  player.currentTime(player.duration() * number * 0.1);
                 }
               }
 


### PR DESCRIPTION
Hi!

Problem: While focus is on player, Numbers [0..9] react as expected - rewinds player to specific % of video. But, if `Command + Number`, `Ctrl + Number` or `Alt + Number` is pressed, player behaves same. This combination is usually set to browsers `Select Tab Hotkey` ( Go to Nth Tab )

Solution: I realize, that someone would like this behavior, and for backwards compatibility, this logic should stay as default. But, if it's unexpected, let's give an option to react only if Number is pressed without modifiers. This is done by adding new default option - `enableModifiersForNumbers`