### PR TITLE
Allow numbers override function

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Any override functions that you build **must** return a boolean.
 - `volumeDownKey` (function): This function can override the key for decreasing the volume (Default key: **Down Arrow**)
 - `muteKey` (function): This function can override the key for the volume muting toggle (Default key: **M**)
 - `fullscreenKey` (function): This function can override the key for the fullscreen toggle (Default key: **F**)
+- `percentNumberKey` (function): This function can override the key for number keys (Default key: **0-9**)
 
 These allow you to change keys such as, instead of, or in addition to, "F" for Fullscreen, you can make Ctrl+Enter trigger fullscreen as well.
 Example usage:

--- a/videojs.hotkeys.js
+++ b/videojs.hotkeys.js
@@ -40,6 +40,7 @@
       volumeDownKey: volumeDownKey,
       muteKey: muteKey,
       fullscreenKey: fullscreenKey,
+      percentNumberKey: percentNumberKey,
       customKeys: {}
     };
 
@@ -49,7 +50,8 @@
       cVolumeUp = 4,
       cVolumeDown = 5,
       cMute = 6,
-      cFullscreen = 7;
+      cFullscreen = 7,
+      cPercentNumber = 8;
 
     // Use built-in merge function from Video.js v5.0+ or v4.4.0+
     var mergeOptions = videojs.mergeOptions || videojs.util.mergeOptions;
@@ -105,6 +107,7 @@
 
     var keyDown = function keyDown(event) {
       var ewhich = event.which, curTime;
+
       var ePreventDefault = event.preventDefault;
       // When controls are disabled, hotkeys will be disabled as well
       if (player.controls()) {
@@ -189,8 +192,8 @@
               }
               break;
 
-            default:
-              // Number keys from 0-9 skip to a percentage of the video. 0 is 0% and 9 is 90%
+            // Number keys from 0-9 skip to a percentage of the video. 0 is 0% and 9 is 90%
+            case cPercentNumber:
               if ((ewhich > 47 && ewhich < 59) || (ewhich > 95 && ewhich < 106)) {
                 // Do not handle if enableModifiersForNumbers set to false and keys are Ctrl, Cmd or Alt
                 if (enableModifiersForNumbers || !(event.metaKey || event.ctrlKey || event.altKey)) {
@@ -205,7 +208,9 @@
                   }
                 }
               }
+              break;
 
+            default:
               // Handle any custom hotkeys
               for (var customKey in options.customKeys) {
                 var customHotkey = options.customKeys[customKey];
@@ -306,6 +311,11 @@
       if (options.fullscreenKey(e, player)) {
         return cFullscreen;
       }
+
+      // Percent Number check
+      if (options.percentNumberKey(e, player)) {
+        return cPercentNumber;
+      }
     };
 
     function playPauseKey(e) {
@@ -341,6 +351,11 @@
     function fullscreenKey(e) {
       // F key
       return (e.which === 70);
+    }
+
+    function percentNumberKey(e) {
+      // 0-9 Number Keys
+      return (e.which > 47 && e.which < 59) || (e.which > 95 && e.which < 106);
     }
 
     player.on('keydown', keyDown);


### PR DESCRIPTION
This exposes `percentNumberKey` which allows us to pass in custom numbers override function if we need to. 
