### PR TITLE
Add option for enabling userinactive focus

### DIFF
--- a/videojs.hotkeys.js
+++ b/videojs.hotkeys.js
@@ -40,7 +40,8 @@
       volumeDownKey: volumeDownKey,
       muteKey: muteKey,
       fullscreenKey: fullscreenKey,
-      customKeys: {}
+      customKeys: {},
+      enableInactiveFocus: true
     };
 
     var cPlay = 1,
@@ -63,7 +64,8 @@
       enableNumbers = options.enableNumbers,
       enableJogStyle = options.enableJogStyle,
       alwaysCaptureHotkeys = options.alwaysCaptureHotkeys,
-      enableModifiersForNumbers = options.enableModifiersForNumbers;
+      enableModifiersForNumbers = options.enableModifiersForNumbers,
+      enableInactiveFocus = options.enableInactiveFocus;
 
     // Set default player tabindex to handle keydown and doubleclick events
     if (!pEl.hasAttribute('tabIndex')) {
@@ -79,20 +81,22 @@
       });
     }
 
-    player.on('userinactive', function() {
-      // When the control bar fades, re-apply focus to the player if last focus was a control button
-      var cancelFocusingPlayer = function() {
-        clearTimeout(focusingPlayerTimeout);
-      };
-      var focusingPlayerTimeout = setTimeout(function() {
-        player.off('useractive', cancelFocusingPlayer);
-        if (doc.activeElement.parentElement == pEl.querySelector('.vjs-control-bar')) {
-          pEl.focus();
-        }
-      }, 10);
+    if (enableInactiveFocus) {
+      player.on('userinactive', function() {
+        // When the control bar fades, re-apply focus to the player if last focus was a control button
+        var cancelFocusingPlayer = function() {
+          clearTimeout(focusingPlayerTimeout);
+        };
+        var focusingPlayerTimeout = setTimeout(function() {
+          player.off('useractive', cancelFocusingPlayer);
+          if (doc.activeElement.parentElement == pEl.querySelector('.vjs-control-bar')) {
+            pEl.focus();
+          }
+        }, 10);
 
-      player.one('useractive', cancelFocusingPlayer);
-    });
+        player.one('useractive', cancelFocusingPlayer);
+      });
+    }
 
     player.on('play', function() {
       // Fix allowing the YouTube plugin to have hotkey support.


### PR DESCRIPTION
When video paused and page is scrolled where the player is not visible, code for setting focus to the controlbar in userinactive event cause page to scroll up to the video again. Which is undesired in some cases. By simply adding an option to enable/disable this behaviour it is possible to overcome this glitch. #39