### PR TITLE
Allow seekTime to be a function

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ videojs('vidId').ready(function() {
 ## Options
 
 - `volumeStep` (decimal): The percentage to increase/decrease the volume level when using the Up and Down Arrow keys (default: `0.1`)
-- `seekStep` (integer): The number of seconds to seek forward and backwards when using the Right and Left Arrow keys (default: `5`)
+- `seekStep` (integer or function): The number of seconds to seek forward and backwards when using the Right and Left Arrow keys (default: `5`), or a function that generates such an integer given the `KeyboardEvent`
 - `enableMute` (boolean): Enables the volume mute to be toggle by pressing the **M** key (default: `true`)
 - `enableVolumeScroll` (boolean): Enables increasing/decreasing the volume by scrolling the mouse wheel (default: `true`)
 - `enableFullscreen` (boolean): Enables toggling the video fullscreen by pressing the **F** key (default: `true`)

--- a/example.html
+++ b/example.html
@@ -42,6 +42,19 @@
           enableNumbers: false,
           enableVolumeScroll: true,
 
+          // Mimic VLC seek behavior, and default to 5.
+          seekStep: function(e) {
+            if (e.ctrlKey && e.altKey) {
+              return 5*60;
+            } else if (e.ctrlKey) {
+              return 60;
+            } else if (e.altKey) {
+              return 10;
+            } else {
+              return 5;
+            }
+          },
+
           // Enhance existing simple hotkey with a complex hotkey
           fullscreenKey: function(e) {
             // fullscreen with the F key or Ctrl+Enter

--- a/videojs.hotkeys.js
+++ b/videojs.hotkeys.js
@@ -152,7 +152,8 @@
               if (wasPlaying) {
                 player.pause();
               }
-              seekTime = player.currentTime() - seekStep;
+              seekTime = player.currentTime() -
+                (typeof seekStep === "function" ? seekStep(event) : seekStep);
               // The flash player tech will allow you to seek into negative
               // numbers and break the seekbar, so try to prevent that.
               if (player.currentTime() <= seekStep) {
@@ -169,7 +170,8 @@
               if (wasPlaying) {
                 player.pause();
               }
-              seekTime = player.currentTime() + seekStep;
+              seekTime = player.currentTime() +
+                (typeof seekStep === "function" ? seekStep(event) : seekStep);
               // Fixes the player not sending the end event if you
               // try to seek past the duration on the seekbar.
               if (seekTime >= duration) {


### PR DESCRIPTION
[VLC provides various levels of granularity in the seek hotkeys](https://www.guidingtech.com/10427/best-vlc-media-player-keyboard-shortcuts/).  Here is a small PR that makes it easy for someone to implement this behavior in videojs-hotkeys (as in the revised `example.html`), by specifying a function instead of an integer for `seekStep`.