### PR TITLE
Only change volume on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ videojs('vidId').ready(function() {
 - `seekStep` (integer or function): The number of seconds to seek forward and backwards when using the Right and Left Arrow keys, or a function that generates an integer given the `KeyboardEvent` (default: `5`)
 - `enableMute` (boolean): Enables the volume mute to be toggle by pressing the **M** key (default: `true`)
 - `enableVolumeScroll` (boolean): Enables increasing/decreasing the volume by scrolling the mouse wheel (default: `true`)
+- `enableHoverScroll` (boolean): Only changes volume when hovering over volume element (default: `true`)
 - `enableFullscreen` (boolean): Enables toggling the video fullscreen by pressing the **F** key (default: `true`)
 - `enableNumbers` (boolean): Enables seeking the video by pressing the number keys (default `true`)
 - `enableModifiersForNumbers` (boolean): Enables the use of Ctrl/Alt/Cmd + Number keys for skipping around in the video, instead of switching browser tabs. This is enabled by default due to backwards compatibility [PR #35](https://github.com/ctd1500/videojs-hotkeys/pull/35) (default: `true`)

--- a/example.html
+++ b/example.html
@@ -41,6 +41,7 @@
           enableFullscreen: true,
           enableNumbers: false,
           enableVolumeScroll: true,
+          enableHoverScroll: true,
 
           // Mimic VLC seek behavior, and default to 5.
           seekStep: function(e) {

--- a/videojs.hotkeys.js
+++ b/videojs.hotkeys.js
@@ -31,6 +31,7 @@
       seekStep: 5,
       enableMute: true,
       enableVolumeScroll: true,
+      enableHoverScroll: true,
       enableFullscreen: true,
       enableNumbers: true,
       enableJogStyle: false,
@@ -64,6 +65,7 @@
       seekStep = options.seekStep,
       enableMute = options.enableMute,
       enableVolumeScroll = options.enableVolumeScroll,
+      enableHoverScroll = options.enableHoverScroll,
       enableFull = options.enableFullscreen,
       enableNumbers = options.enableNumbers,
       enableJogStyle = options.enableJogStyle,
@@ -282,15 +284,27 @@
       }
     };
 
+    var volumeHover = false;
+    var volumeSelector = pEl.querySelector('.vjs-volume-menu-button') || pEl.querySelector('.vjs-volume-panel');
+    volumeSelector.onmouseover = function() { volumeHover = true; }
+    volumeSelector.onmouseout = function() { volumeHover = false; }
+    
     var mouseScroll = function mouseScroll(event) {
+      if (enableHoverScroll) {
+        // If we leave this undefined then it can match non-existent elements below
+        var activeEl = 0;
+      } else {
+        var activeEl = doc.activeElement;
+      }
+
       // When controls are disabled, hotkeys will be disabled as well
       if (player.controls()) {
-        var activeEl = doc.activeElement;
         if (alwaysCaptureHotkeys ||
             activeEl == pEl ||
             activeEl == pEl.querySelector('.vjs-tech') ||
             activeEl == pEl.querySelector('.iframeblocker') ||
-            activeEl == pEl.querySelector('.vjs-control-bar')) {
+            activeEl == pEl.querySelector('.vjs-control-bar') ||
+            volumeHover) {
 
           if (enableVolumeScroll) {
             event = window.event || event;


### PR DESCRIPTION
Currently if a user scrolls anywhere within the player then the scroll event is captured. This interferes with other player elements, notably making it difficult to scroll through captions. This PR makes it so that the volume will only change when the user is hovering over the volume element, similar to how YouTube's volume scroll works. This change is compatible with VideoJS 6 and 7.

Let me know if you'd like me to fix anything!