### PR TITLE
Fix setting properties on null object

### DIFF
--- a/videojs.hotkeys.js
+++ b/videojs.hotkeys.js
@@ -403,7 +403,7 @@
     }
 
     function silencePromise(value) {
-      if (value !== undefined && value !== null && typeof value.then === 'function') {
+      if (value != null && typeof value.then === 'function') {
         value.then(null, function(e) {});
       }
     }

--- a/videojs.hotkeys.js
+++ b/videojs.hotkeys.js
@@ -286,8 +286,10 @@
 
     var volumeHover = false;
     var volumeSelector = pEl.querySelector('.vjs-volume-menu-button') || pEl.querySelector('.vjs-volume-panel');
-    volumeSelector.onmouseover = function() { volumeHover = true; };
-    volumeSelector.onmouseout = function() { volumeHover = false; };
+    if (volumeSelector != null) {
+      volumeSelector.onmouseover = function() { volumeHover = true; };
+      volumeSelector.onmouseout = function() { volumeHover = false; };
+    }
 
     var mouseScroll = function mouseScroll(event) {
       if (enableHoverScroll) {


### PR DESCRIPTION
`volumeSelector` could be `null` (as in our case) and setting `onmouseover` on it blows up with a NPE on the new version. This PR fixes that. The second commit is just code-style.