### PR TITLE
Fix control with captureDocumentHotkeys enabled

### DIFF
--- a/videojs.hotkeys.js
+++ b/videojs.hotkeys.js
@@ -147,7 +147,7 @@
             // Spacebar toggles play/pause
             case cPlay:
               ePreventDefault();
-              if (alwaysCaptureHotkeys) {
+              if (alwaysCaptureHotkeys || captureDocumentHotkeys) {
                 // Prevent control activation with space
                 event.stopPropagation();
               }


### PR DESCRIPTION
If the option is enabled and the `video` element is focused, play/pause hotkey does not work when `captureDocumentHotkeys` is enabled.

See https://github.com/Chocobozzz/PeerTube/issues/3013