### PR TITLE
Update README to add npm installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ Or always load the latest version:
 <script src="/path/to/videojs.hotkeys.js"></script>
 ```
 
+### npm version
+You can also install it as a package from npm:
+```sh
+npm install --save videojs-hotkeys
+```
+and include it in your project by importing it:
+```js
+import "videojs-hotkeys";
+```
+
 ### Enable the plugin
 Add hotkeys to your Videojs ready function.
 Check the [Options](#options) section below for the available options and their meaning.


### PR DESCRIPTION
Noticed that there was, strangely, no information at all about how to install it as a npm module even though there's been work done to support it. Added this info to the README.