### PR TITLE
Add TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,41 @@
+import { VideoJsPlayer } from 'video.js';
+
+declare module 'video.js' {
+    interface VideoJsPlayer {
+        hotkeys(options: VideoJsHotkeysOptions): void;
+    }
+}
+
+export interface VideoJsHotkeysOptions {
+    volumeStep?: number;
+    seekStep?: number;
+    enableMute?: boolean;
+    enableVolumeScroll?: boolean;
+    enableHoverScroll?: boolean;
+    enableFullscreen?: boolean;
+    enableNumbers?: boolean;
+    enableModifiersForNumbers?: boolean;
+    alwaysCaptureHotkeys?: boolean;
+    enableInactiveFocus?: boolean;
+    skipInitialFocus?: boolean;
+    captureDocumentHotkeys?: boolean;
+    documentHotkeysFocusElementFilter?: (element: HTMLElement) => boolean;
+    enableJogStyle?: boolean;
+    playPauseKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    rewindKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    forwardKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    volumeUpKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    volumeDownKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    muteKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    fullscreenKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    customKeys?: VideoJsCustomHotkeyOptions;
+}
+
+export interface VideoJsCustomHotkeyOptions {
+    [key: string]: VideoJsCustomHotkey;
+}
+
+export interface VideoJsCustomHotkey {
+    key: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
+    handler: (player: VideoJsPlayer, options: VideoJsHotkeysOptions, event: KeyboardEvent) => void;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import { VideoJsPlayer } from 'video.js';
 
 declare module 'video.js' {
     interface VideoJsPlayer {
-        hotkeys(options: VideoJsHotkeysOptions): void;
+        hotkeys(options?: VideoJsHotkeysOptions): void;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -30,5 +30,6 @@
   "scripts": {
     "build": "grunt",
     "release": "grunt release"
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
Created TypeScript definitions for this project after following this guide https://joeflateau.net/posts/video-js-heart-typescript

This would fix the issue where referencing `this.hotkeys` gives a type error if used within a TypeScript project, because now the typing for this plugin is injected into the definition for `VideoJsPlayer`.

This should hopefully make this project viable for use within a TypeScript project.