### PR TITLE
Update type definitions to match updates made in DefinitelyTyped definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,28 +7,28 @@ declare module 'video.js' {
 }
 
 export interface VideoJsHotkeysOptions {
-    volumeStep?: number;
-    seekStep?: number;
-    enableMute?: boolean;
-    enableVolumeScroll?: boolean;
-    enableHoverScroll?: boolean;
-    enableFullscreen?: boolean;
-    enableNumbers?: boolean;
-    enableModifiersForNumbers?: boolean;
-    alwaysCaptureHotkeys?: boolean;
-    enableInactiveFocus?: boolean;
-    skipInitialFocus?: boolean;
-    captureDocumentHotkeys?: boolean;
-    documentHotkeysFocusElementFilter?: (element: HTMLElement) => boolean;
-    enableJogStyle?: boolean;
-    playPauseKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
-    rewindKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
-    forwardKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
-    volumeUpKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
-    volumeDownKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
-    muteKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
-    fullscreenKey?: (event: KeyboardEvent, player: VideoJsPlayer) => boolean;
-    customKeys?: VideoJsCustomHotkeyOptions;
+    volumeStep?: number | undefined;
+    seekStep?: number | undefined;
+    enableMute?: boolean | undefined;
+    enableVolumeScroll?: boolean | undefined;
+    enableHoverScroll?: boolean | undefined;
+    enableFullscreen?: boolean | undefined;
+    enableNumbers?: boolean | undefined;
+    enableModifiersForNumbers?: boolean | undefined;
+    alwaysCaptureHotkeys?: boolean | undefined;
+    enableInactiveFocus?: boolean | undefined;
+    skipInitialFocus?: boolean | undefined;
+    captureDocumentHotkeys?: boolean | undefined;
+    documentHotkeysFocusElementFilter?: ((element: HTMLElement) => boolean) | undefined;
+    enableJogStyle?: boolean | undefined;
+    playPauseKey?: ((event: KeyboardEvent, player: VideoJsPlayer) => boolean) | undefined;
+    rewindKey?: ((event: KeyboardEvent, player: VideoJsPlayer) => boolean) | undefined;
+    forwardKey?: ((event: KeyboardEvent, player: VideoJsPlayer) => boolean) | undefined;
+    volumeUpKey?: ((event: KeyboardEvent, player: VideoJsPlayer) => boolean) | undefined;
+    volumeDownKey?: ((event: KeyboardEvent, player: VideoJsPlayer) => boolean) | undefined;
+    muteKey?: ((event: KeyboardEvent, player: VideoJsPlayer) => boolean) | undefined;
+    fullscreenKey?: ((event: KeyboardEvent, player: VideoJsPlayer) => boolean) | undefined;
+    customKeys?: VideoJsCustomHotkeyOptions | undefined;
 }
 
 export interface VideoJsCustomHotkeyOptions {


### PR DESCRIPTION
TypeScript 4.4 adds "exactOptionalPropertyTypes" setting, which if enabled, will fail type check if undefined is explicitly passed to an optional property. By making the undefined property explicitly, there will be no errors, even if the setting is enabled.

https://github.com/DefinitelyTyped/DefinitelyTyped/commit/29216607f433cbb900acdcf4a0e4ea69e9db5376 https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes

The type definitions were added to DefinitelyTyped before they were merged directly into this project. PR https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63785 will remove them from DefinitelyTyped since they're here now.