### PR TITLE
Fix types for the latest `video.js`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
-import { VideoJsPlayer } from 'video.js';
+import VideoJsPlayer from 'video.js/dist/types/player';
 
-declare module 'video.js' {
-    interface VideoJsPlayer {
+declare module 'video.js/dist/types/player' {
+    export default interface VideoJsPlayer {
         hotkeys(options?: VideoJsHotkeysOptions): void;
     }
 }


### PR DESCRIPTION
8.17.3 as of this commit.

cc @ctd1500 